### PR TITLE
fix variadic template in is_in_types

### DIFF
--- a/YBase/include/ystdex/meta.hpp
+++ b/YBase/include/ystdex/meta.hpp
@@ -715,7 +715,7 @@ struct are_same : and_<is_same<_type, _types>...>
 
 //! \brief 判断第一个参数在之后参数指定的类型中出现。
 template<typename _type, typename... _types>
-struct is_in_types : or_<is_same<_type, _types...>>
+struct is_in_types : or_<is_same<_type, _types>...>
 {};
 //@}
 


### PR DESCRIPTION
It is only used in `is_char_specialized_in_std`, which is never instantiated in the project.